### PR TITLE
Adding useful prometheus metrics

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ requests = "==2.21.0"
 sqlparse = "==0.3.0"
 whitenoise = "==4.1.2"
 django-prometheus = "==1.0.15"
+prometheus-client = "==0.5.0"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8de0b9ca99ea70b952f05aad3b198a7b6c9b2c7e3405515b2dcf6d2e3a265e03"
+            "sha256": "228193ad54dd33f6024fb0a7364e9583663827a0e7095be971830b2e04b541dd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -86,16 +86,17 @@
         },
         "kafka-python": {
             "hashes": [
-                "sha256:08f83d8e0af2e64d25f94314d4bef6785b34e3b0df0effe9eebf76b98de66eeb",
-                "sha256:3f55bb3e125764a37da550e9fa3d10a85fa09f8af8f8a40f223d2ec8486c2a5b"
+                "sha256:078acdcd1fc6eddacc46d437c664998b4cf7613b7e79ced66a460965f2648f88",
+                "sha256:0b56f286b674dcb331d80c1d39a01a753cc3acc962bee707da5f207db74f0a26"
             ],
-            "version": "==1.4.6"
+            "version": "==1.4.3"
         },
         "prometheus-client": {
             "hashes": [
-                "sha256:1b38b958750f66f208bcd9ab92a633c0c994d8859c831f7abc1f46724fcee490"
+                "sha256:e8c11ff5ca53de6c3d91e1510500611cafd1d247a937ec6c588a0a7cc3bef93c"
             ],
-            "version": "==0.6.0"
+            "index": "pypi",
+            "version": "==0.5.0"
         },
         "psycopg2-binary": {
             "hashes": [
@@ -128,14 +129,15 @@
                 "sha256:ed772a5e8e7e5dd6bede960a86940c17cf653c7f158dafa5d52e919b676f10ba",
                 "sha256:f2d73131acb94afa45de8b6b8a4bfb21bbe3736633d6478e53247f19dd8c299c"
             ],
+            "index": "pypi",
             "version": "==2.8.1"
         },
         "pytz": {
             "hashes": [
-                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
-                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
+                "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda",
+                "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
             ],
-            "version": "==2018.9"
+            "version": "==2019.1"
         },
         "requests": {
             "hashes": [
@@ -196,6 +198,7 @@
                 "sha256:bbeb45bb41344d2cbb814b4c89c04f2c568742352736cabf7af6fcbed06f66cc",
                 "sha256:cce5f4c64a24bd05a31721e45fd9fe39ff0a9987d7a1351d00b1037a8744238a"
             ],
+            "index": "pypi",
             "version": "==0.12.3"
         },
         "autopep8": {
@@ -442,10 +445,9 @@
         },
         "port-for": {
             "hashes": [
-                "sha256:247b4db1901aa3d9906258308e40dfbadf65275b27ca77faa0b9a876b7284970",
-                "sha256:47b5cb48f8e036497cd73b96de305cecb4070e9ecbc908724afcbd2224edccde"
+                "sha256:b16a84bb29c2954db44c29be38b17c659c9c27e33918dec16b90d375cc596f1c"
             ],
-            "version": "==0.4"
+            "version": "==0.3.1"
         },
         "py": {
             "hashes": [
@@ -507,10 +509,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
-                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
+                "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda",
+                "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
             ],
-            "version": "==2018.9"
+            "version": "==2019.1"
         },
         "pyyaml": {
             "hashes": [
@@ -563,6 +565,7 @@
                 "sha256:423280646fb37944dd3c85c58fb92a20d745793a9f6c511f59da82fa97cd404b",
                 "sha256:de930f42600a4fef993587633984cc5027dedba2464bcf00ddace26b40f8d9ce"
             ],
+            "index": "pypi",
             "version": "==2.0.1"
         },
         "sphinx-autobuild": {
@@ -597,10 +600,10 @@
         },
         "sphinxcontrib-htmlhelp": {
             "hashes": [
-                "sha256:0d691ca8edf5995fbacfe69b191914256071a94cbad03c3688dca47385c9206c",
-                "sha256:e31c8271f5a8f04b620a500c0442a7d5cfc1a732fa5c10ec363f90fe72af0cb8"
+                "sha256:4670f99f8951bd78cd4ad2ab962f798f5618b17675c35c5ac3b2132a14ea8422",
+                "sha256:d4fd39a65a625c9df86d7fa8a2d9f3cd8299a3a4b15db63b50aac9e161d8eff7"
             ],
-            "version": "==1.0.1"
+            "version": "==1.0.2"
         },
         "sphinxcontrib-jsmath": {
             "hashes": [
@@ -618,10 +621,10 @@
         },
         "sphinxcontrib-serializinghtml": {
             "hashes": [
-                "sha256:01d9b2617d7e8ddf7a00cae091f08f9fa4db587cc160b493141ee56710810932",
-                "sha256:392187ac558863b8aff0d76dc78e0731fed58f3b06e2b00e22995dcdb630f213"
+                "sha256:c0efb33f8052c04fd7a26c0a07f1678e8512e0faec19f4aa8f2473a8b81d5227",
+                "sha256:db6615af393650bf1151a6cd39120c29abaf93cc60db8c48eb2dddbfdc3a9768"
             ],
-            "version": "==1.1.1"
+            "version": "==1.1.3"
         },
         "toml": {
             "hashes": [
@@ -648,6 +651,7 @@
                 "sha256:69620e19de33a6b7ee8aeda5478791b3618ff58f0b869dbd0319fb71aa903deb",
                 "sha256:e5cdb1653aa27b3e46b5c390de6b6d51d31afcfdbd9d1222d82d76b82ad03d9b"
             ],
+            "index": "pypi",
             "version": "==3.8.6"
         },
         "typed-ast": {

--- a/yupana/processor/report_processor.py
+++ b/yupana/processor/report_processor.py
@@ -74,7 +74,8 @@ HOST_UPLOAD_REQUEST_LATENCY = Summary(
     'inventory_upload_latency',
     'The time in seconds that it takes to post to the host inventory')
 VALIDATION_LATENCY = Summary('validation_latency', 'The time it takes to validate a report')
-HOSTS_PER_REPORT = Gauge('hosts_per_report', 'The total number of hosts per report')
+INVALID_HOSTS = Gauge('invalid_hosts_per_report', 'The total number of invalid hosts per report')
+VALID_HOSTS = Gauge('valid_hosts_per_report', 'The total number of valid hosts per report')
 HOSTS_UPLOADED_SUCCESS = Gauge('hosts_uploaded', 'The total number of hosts successfully uploaded')
 HOSTS_UPLOADED_FAILED = Gauge('hosts_failed', 'The total number of hosts that fail to upload')
 
@@ -314,6 +315,7 @@ class ReportProcessor():  # pylint: disable=too-many-instance-attributes
             account_number=self.account_number))
         try:
             self.candidate_hosts, self.failed_hosts = self._validate_report_details()
+            INVALID_HOSTS.set(len(self.failed_hosts))
             self.report_id = self.report_json.get('report_platform_id')
             self.status = SUCCESS_CONFIRM_STATUS
             self.next_state = Report.VALIDATED
@@ -1156,7 +1158,7 @@ class ReportProcessor():  # pylint: disable=too-many-instance-attributes
         total_hosts_count = len(hosts)
         failed_hosts_count = len(failed_hosts)
         successful = total_hosts_count - failed_hosts_count
-        HOSTS_PER_REPORT.set(total_hosts_count)
+        VALID_HOSTS.set(total_hosts_count)
         HOSTS_UPLOADED_SUCCESS.set(successful)
         HOSTS_UPLOADED_FAILED.set(failed_hosts_count)
         upload_msg = format_message(

--- a/yupana/processor/tests_report_processor.py
+++ b/yupana/processor/tests_report_processor.py
@@ -464,9 +464,12 @@ class ReportProcessorTests(TestCase):
             'report_version': '1.0.0.1b025b8',
             'status': 'completed',
             'report_platform_id': '5f2cc1fd-ec66-4c67-be1b-171a595ce319',
-            'hosts': {self.uuid: {'bios_uuid': 'value'}}}
+            'hosts': {self.uuid: {'bios_uuid': 'value'},
+                      self.uuid2: {'foo': 'bar'}}}
         self.processor.transition_to_validated()
+        invalid_hosts = REGISTRY.get_sample_value('invalid_hosts_per_report')
         self.assertEqual(self.report_record.state, Report.VALIDATED)
+        self.assertEqual(invalid_hosts, 1)
 
     def test_transition_to_validated_report_exception(self):
         """Test that a report with invalid type is still marked as validated."""
@@ -1139,7 +1142,7 @@ class ReportProcessorTests(TestCase):
                 self.processor._upload_to_host_inventory(hosts)
             self.assertEqual(retry_time_hosts, [])
             self.assertEqual(retry_commit_hosts, [])
-            total_hosts = REGISTRY.get_sample_value('hosts_per_report')
+            total_hosts = REGISTRY.get_sample_value('valid_hosts_per_report')
             uploaded_hosts = REGISTRY.get_sample_value('hosts_uploaded')
             failed_hosts = REGISTRY.get_sample_value('hosts_failed')
             self.assertEqual(total_hosts, 7)
@@ -1164,7 +1167,7 @@ class ReportProcessorTests(TestCase):
             for host in expected_hosts:
                 self.assertIn(host, retry_time_hosts)
             self.assertEqual(retry_commit_hosts, [])
-            total_hosts = REGISTRY.get_sample_value('hosts_per_report')
+            total_hosts = REGISTRY.get_sample_value('valid_hosts_per_report')
             uploaded_hosts = REGISTRY.get_sample_value('hosts_uploaded')
             failed_hosts = REGISTRY.get_sample_value('hosts_failed')
             self.assertEqual(total_hosts, 2)
@@ -1189,7 +1192,7 @@ class ReportProcessorTests(TestCase):
             for host in expected_hosts:
                 self.assertIn(host, retry_commit_hosts)
             self.assertEqual(retry_time_hosts, [])
-            total_hosts = REGISTRY.get_sample_value('hosts_per_report')
+            total_hosts = REGISTRY.get_sample_value('valid_hosts_per_report')
             uploaded_hosts = REGISTRY.get_sample_value('hosts_uploaded')
             failed_hosts = REGISTRY.get_sample_value('hosts_failed')
             self.assertEqual(total_hosts, 2)
@@ -1214,7 +1217,7 @@ class ReportProcessorTests(TestCase):
             for host in expected_hosts:
                 self.assertIn(host, retry_time_hosts)
             self.assertEqual(retry_commit_hosts, [])
-            total_hosts = REGISTRY.get_sample_value('hosts_per_report')
+            total_hosts = REGISTRY.get_sample_value('valid_hosts_per_report')
             uploaded_hosts = REGISTRY.get_sample_value('hosts_uploaded')
             failed_hosts = REGISTRY.get_sample_value('hosts_failed')
             self.assertEqual(total_hosts, 2)
@@ -1253,7 +1256,7 @@ class ReportProcessorTests(TestCase):
             self.assertEqual(retry_commit, [])
             for host in expected_hosts:
                 self.assertIn(host, retry_time)
-            total_hosts = REGISTRY.get_sample_value('hosts_per_report')
+            total_hosts = REGISTRY.get_sample_value('valid_hosts_per_report')
             uploaded_hosts = REGISTRY.get_sample_value('hosts_uploaded')
             failed_hosts = REGISTRY.get_sample_value('hosts_failed')
             self.assertEqual(total_hosts, 2)
@@ -1298,7 +1301,7 @@ class ReportProcessorTests(TestCase):
             self.assertEqual(retry_time_hosts, [])
             for host in expected_hosts:
                 self.assertIn(host, retry_commit_hosts)
-            total_hosts = REGISTRY.get_sample_value('hosts_per_report')
+            total_hosts = REGISTRY.get_sample_value('valid_hosts_per_report')
             uploaded_hosts = REGISTRY.get_sample_value('hosts_uploaded')
             failed_hosts = REGISTRY.get_sample_value('hosts_failed')
             self.assertEqual(total_hosts, 7)

--- a/yupana/processor/tests_report_processor.py
+++ b/yupana/processor/tests_report_processor.py
@@ -1145,9 +1145,11 @@ class ReportProcessorTests(TestCase):
             total_hosts = REGISTRY.get_sample_value('valid_hosts_per_report')
             uploaded_hosts = REGISTRY.get_sample_value('hosts_uploaded')
             failed_hosts = REGISTRY.get_sample_value('hosts_failed')
+            upload_group_size = REGISTRY.get_sample_value('upload_group_size')
             self.assertEqual(total_hosts, 7)
             self.assertEqual(uploaded_hosts, 7)
             self.assertEqual(failed_hosts, 0)
+            self.assertEqual(upload_group_size, 7)
 
     def test_no_json_resp_host_inventory_upload(self):
         """Testing unsuccessful upload to host inventory."""
@@ -1170,9 +1172,11 @@ class ReportProcessorTests(TestCase):
             total_hosts = REGISTRY.get_sample_value('valid_hosts_per_report')
             uploaded_hosts = REGISTRY.get_sample_value('hosts_uploaded')
             failed_hosts = REGISTRY.get_sample_value('hosts_failed')
+            upload_group_size = REGISTRY.get_sample_value('upload_group_size')
             self.assertEqual(total_hosts, 2)
             self.assertEqual(uploaded_hosts, 0)
             self.assertEqual(failed_hosts, 2)
+            self.assertEqual(upload_group_size, 2)
 
     def test_400_resp_host_inventory_upload(self):
         """Testing unsuccessful upload to host inventory."""
@@ -1195,9 +1199,11 @@ class ReportProcessorTests(TestCase):
             total_hosts = REGISTRY.get_sample_value('valid_hosts_per_report')
             uploaded_hosts = REGISTRY.get_sample_value('hosts_uploaded')
             failed_hosts = REGISTRY.get_sample_value('hosts_failed')
+            upload_group_size = REGISTRY.get_sample_value('upload_group_size')
             self.assertEqual(total_hosts, 2)
             self.assertEqual(uploaded_hosts, 0)
             self.assertEqual(failed_hosts, 2)
+            self.assertEqual(upload_group_size, 2)
 
     def test_500_resp_host_inventory_upload(self):
         """Testing unsuccessful upload to host inventory."""
@@ -1220,9 +1226,11 @@ class ReportProcessorTests(TestCase):
             total_hosts = REGISTRY.get_sample_value('valid_hosts_per_report')
             uploaded_hosts = REGISTRY.get_sample_value('hosts_uploaded')
             failed_hosts = REGISTRY.get_sample_value('hosts_failed')
+            upload_group_size = REGISTRY.get_sample_value('upload_group_size')
             self.assertEqual(total_hosts, 2)
             self.assertEqual(uploaded_hosts, 0)
             self.assertEqual(failed_hosts, 2)
+            self.assertEqual(upload_group_size, 2)
 
     def test_host_inventory_upload_500(self):
         """Testing successful upload to host inventory with 500 errors."""
@@ -1259,9 +1267,11 @@ class ReportProcessorTests(TestCase):
             total_hosts = REGISTRY.get_sample_value('valid_hosts_per_report')
             uploaded_hosts = REGISTRY.get_sample_value('hosts_uploaded')
             failed_hosts = REGISTRY.get_sample_value('hosts_failed')
+            upload_group_size = REGISTRY.get_sample_value('upload_group_size')
             self.assertEqual(total_hosts, 2)
             self.assertEqual(uploaded_hosts, 0)
             self.assertEqual(failed_hosts, 2)
+            self.assertEqual(upload_group_size, 2)
 
     def test_host_inventory_upload_400(self):
         """Testing successful upload to host inventory with 500 errors."""
@@ -1304,9 +1314,11 @@ class ReportProcessorTests(TestCase):
             total_hosts = REGISTRY.get_sample_value('valid_hosts_per_report')
             uploaded_hosts = REGISTRY.get_sample_value('hosts_uploaded')
             failed_hosts = REGISTRY.get_sample_value('hosts_failed')
+            upload_group_size = REGISTRY.get_sample_value('upload_group_size')
             self.assertEqual(total_hosts, 7)
             self.assertEqual(uploaded_hosts, 5)
             self.assertEqual(failed_hosts, 2)
+            self.assertEqual(upload_group_size, 7)
 
     @patch('processor.report_processor.requests.post')
     def test_host_url_exceptions(self, mock_request):


### PR DESCRIPTION
Metrics added: 
===========
   - \# of reports uploaded total
   - \# of reports queued at a given time
   - \# of reports archived as success & failure (separately)
   - \# of reports that fail to download
   - \# of reports that fail validation (can not be validated)
   - \# of reports that are invalid
   - total retries based on time
   - total retries based on commit
   - request latency to upload to host inventory
   - the time it takes to run our validation code
   - \# of valid hosts per report
   - \# of hosts successfully uploaded per report
   - \# of hosts failed per report
   - upload group size per bulk request
   - \# of invalid hosts per report