### PR TITLE
Add metric to capture kafka errors

### DIFF
--- a/scripts/config/yupana-grafana.json
+++ b/scripts/config/yupana-grafana.json
@@ -155,61 +155,61 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(hosts_count_total)",
+            "expr": "sum(yupana_hosts_count_total)",
             "hide": false,
             "legendFormat": "Total Hosts ",
             "refId": "A"
           },
           {
-            "expr": "hosts_count_total{source=\"qpc\"}",
+            "expr": "yupana_hosts_count_total{source=\"qpc\"}",
             "hide": false,
             "legendFormat": "Total QPC Hosts",
             "refId": "B"
           },
           {
-            "expr": "hosts_count_total{source=\"satellite\"}",
+            "expr": "yupana_hosts_count_total{source=\"satellite\"}",
             "hide": false,
             "legendFormat": "Total Satellite Hosts ",
             "refId": "C"
           },
           {
-            "expr": "sum(increase(hosts_count_total[1m]))",
+            "expr": "sum(increase(yupana_hosts_count_total[1m]))",
             "hide": false,
             "legendFormat": "Hosts per minute",
             "refId": "D"
           },
           {
-            "expr": "increase(hosts_count_total{source=\"qpc\"}[1m])",
+            "expr": "increase(yupana_hosts_count_total{source=\"qpc\"}[1m])",
             "legendFormat": "QPC hosts per minute",
             "refId": "E"
           },
           {
-            "expr": "increase(hosts_count_total{source=\"satellite\"}[1m])",
+            "expr": "increase(yupana_hosts_count_total{source=\"satellite\"}[1m])",
             "legendFormat": "Satellite hosts per minute",
             "refId": "F"
           },
           {
-            "expr": "sum(increase(hosts_count_total[1h]))",
+            "expr": "sum(increase(yupana_hosts_count_total[1h]))",
             "legendFormat": "Hosts per hour",
             "refId": "G"
           },
           {
-            "expr": "increase(hosts_count_total{source=\"qpc\"}[1h])",
+            "expr": "increase(yupana_hosts_count_total{source=\"qpc\"}[1h])",
             "legendFormat": "QPC hosts per hour",
             "refId": "H"
           },
           {
-            "expr": "increase(hosts_count_total{source=\"satellite\"}[1h])",
+            "expr": "increase(yupana_hosts_count_total{source=\"satellite\"}[1h])",
             "legendFormat": "Satellite hosts per hour",
             "refId": "I"
           },
           {
-            "expr": "sum(rate(hosts_count_total[1h]))",
+            "expr": "sum(rate(yupana_hosts_count_total[1h]))",
             "legendFormat": "Rate of hosts per hour",
             "refId": "J"
           },
           {
-            "expr": "sum(increase(hosts_count_total[24h]))",
+            "expr": "sum(increase(yupana_hosts_count_total[24h]))",
             "legendFormat": "Hosts uploaded over the last day",
             "refId": "K"
           }
@@ -883,33 +883,33 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "uploaded_messages_total",
+            "expr": "yupana_message_uploads_total",
             "format": "time_series",
             "legendFormat": "Total report uploads",
             "refId": "A"
           },
           {
-            "expr": "rate(uploaded_messages_total[1m])",
+            "expr": "rate(yupana_message_uploads_total[1m])",
             "legendFormat": "Rate of report uploads per minute",
             "refId": "B"
           },
           {
-            "expr": "increase(uploaded_messages_total[1m])",
+            "expr": "increase(yupana_message_uploads_total[1m])",
             "legendFormat": "Total report uploads per min",
             "refId": "C"
           },
           {
-            "expr": "increase(uploaded_messages_total[1h])",
+            "expr": "increase(yupana_message_uploads_total[1h])",
             "legendFormat": "Total report uploads per hour",
             "refId": "D"
           },
           {
-            "expr": "rate(uploaded_messages_total[1h])",
+            "expr": "rate(yupana_message_uploads_total[1h])",
             "legendFormat": "Rate of report uploads per hour",
             "refId": "E"
           },
           {
-            "expr": "increase(uploaded_messages_total[24h])",
+            "expr": "increase(yupana_message_uploads_total[24h])",
             "legendFormat": "Report uploads over the last day",
             "refId": "F"
           }
@@ -1083,5 +1083,5 @@
     "timezone": "",
     "title": "Yupana Dev",
     "uid": "KYkcp45Wk",
-    "version": 5
+    "version": 8
   }

--- a/scripts/config/yupana-grafana.json
+++ b/scripts/config/yupana-grafana.json
@@ -59,7 +59,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "kafka_errors_total",
+            "expr": "yupana_kafka_errors_total",
             "refId": "A"
           }
         ],
@@ -1076,12 +1076,12 @@
       "list": []
     },
     "time": {
-      "from": "now-6h",
+      "from": "now-12h",
       "to": "now"
     },
     "timepicker": {},
     "timezone": "",
     "title": "Yupana Dev",
     "uid": "KYkcp45Wk",
-    "version": 4
+    "version": 5
   }

--- a/scripts/config/yupana-grafana.json
+++ b/scripts/config/yupana-grafana.json
@@ -20,6 +20,92 @@
     "panels": [
       {
         "aliasColors": {
+          "kafka_errors_total{instance=\"docker.for.mac.localhost:8001\",job=\"yupana\"}": "dark-blue"
+        },
+        "bars": true,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 24,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "kafka_errors_total",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Kafka Errors",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {
           "Hosts per hour": "dark-orange",
           "Hosts per minute": "super-light-green",
           "Hosts uploaded over the last day": "semi-dark-blue",
@@ -41,7 +127,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 0
+          "y": 8
         },
         "id": 22,
         "legend": {
@@ -180,7 +266,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 8
+          "y": 16
         },
         "id": 18,
         "legend": {
@@ -264,7 +350,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 16
+          "y": 24
         },
         "id": 16,
         "legend": {
@@ -363,7 +449,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 24
+          "y": 32
         },
         "id": 14,
         "legend": {
@@ -473,7 +559,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 32
+          "y": 40
         },
         "id": 12,
         "legend": {
@@ -568,7 +654,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 40
+          "y": 48
         },
         "id": 8,
         "legend": {
@@ -666,7 +752,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 48
+          "y": 56
         },
         "id": 6,
         "interval": "",
@@ -769,7 +855,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 56
+          "y": 64
         },
         "id": 4,
         "legend": {
@@ -881,7 +967,7 @@
           "h": 9,
           "w": 12,
           "x": 0,
-          "y": 64
+          "y": 72
         },
         "id": 2,
         "legend": {
@@ -997,5 +1083,5 @@
     "timezone": "",
     "title": "Yupana Dev",
     "uid": "KYkcp45Wk",
-    "version": 21
+    "version": 4
   }

--- a/yupana/processor/report_consumer.py
+++ b/yupana/processor/report_consumer.py
@@ -36,7 +36,7 @@ UPLOAD_REPORT_CONSUMER_LOOP = asyncio.get_event_loop()
 REPORT_PENDING_QUEUE = asyncio.Queue()
 QPC_TOPIC = 'platform.upload.qpc'
 
-MSG_UPLOADS = Counter('uploaded_messages',
+MSG_UPLOADS = Counter('yupana_message_uploads',
                       'Number of messages uploaded to qpc topic',
                       ['account_number'])
 

--- a/yupana/processor/report_consumer.py
+++ b/yupana/processor/report_consumer.py
@@ -40,7 +40,7 @@ MSG_UPLOADS = Counter('uploaded_messages',
                       'Number of messages uploaded to qpc topic',
                       ['account_number'])
 
-KAFKA_ERRORS = Counter('kafka_errors', 'Number of Kafka errors')
+KAFKA_ERRORS = Counter('yupana_kafka_errors', 'Number of Kafka errors')
 
 
 def format_message(prefix, message, account_number=None,

--- a/yupana/processor/report_processor.py
+++ b/yupana/processor/report_processor.py
@@ -59,7 +59,7 @@ HOSTS_PER_REPORT_SATELLITE = Gauge('hosts_per_sat_rep',
 HOSTS_PER_REPORT_QPC = Gauge('hosts_per_qpc_rep',
                              'Hosts count in a QPC report',
                              ['account_number'])
-HOSTS_COUNTER = Counter('hosts_count',
+HOSTS_COUNTER = Counter('yupana_hosts_count',
                         'Total number of hosts uploaded',
                         ['account_number', 'source'])
 


### PR DESCRIPTION
Closes #234 

1. Bring up local development - follow the prometheus/grafana instructions 
2. Either send a lot of reports & kill the file upload service during that or you can bring up the server without the file upload service running. (graphs can be finicky - so play around with it) 