### PR TITLE
Updated the services defined for the yupana smoke tests

### DIFF
--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -12,9 +12,9 @@ if (env.CHANGE_ID) {
         // the service-set/component for this app in e2e-deploy "buildfactory"
         ocDeployerBuilderPath: "subscriptions/yupana",
         // the service-set/component for this app in e2e-deploy "templates"
-        ocDeployerComponentPath: "subscriptions/yupana",
+        ocDeployerComponentPath: "subscriptions",
         // the service sets to deploy into the test environment
-        ocDeployerServiceSets: "upload-service,insights-inventory,subscriptions",
+        ocDeployerServiceSets: "platform,platform-mq,subscriptions",
         // the iqe plugins to install for the test
         iqePlugins: ["iqe-yupana-plugin"],
         // the pytest marker to use when calling `iqe tests all`

--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -18,7 +18,7 @@ if (env.CHANGE_ID) {
         // the iqe plugins to install for the test
         iqePlugins: ["iqe-yupana-plugin"],
         // the pytest marker to use when calling `iqe tests all`
-        pytestMarker: "yupana-smoke",
+        pytestMarker: "yupana_smoke",
         // optional id for an IQE configuration file stored as a secret in Jenkins
         //configFileCredentialsId: "myId",
     )


### PR DESCRIPTION
While working on a temporary test jenkins job for the yupana smoke tests, we learned that some of the services needed to be switched.

This updates the `Jenkinsfile-smoke.groovy` to match the working pipeline from the test job.