### PR TITLE
Fix create report logic to have even slices.

### DIFF
--- a/scripts/create_report.py
+++ b/scripts/create_report.py
@@ -98,7 +98,9 @@ class extend_report():
         number_hosts = self.target_hosts
         if number_hosts % self.slice_max:
             number_of_slices = number_hosts // self.slice_max + 1
-            hosts_per_slice = number_hosts // number_of_slices + 1
+            hosts_per_slice = number_hosts // number_of_slices
+            if number_hosts > self.slice_max:
+                 hosts_per_slice += 1
         else:
             number_of_slices = number_hosts // self.slice_max
             hosts_per_slice = number_hosts // number_of_slices

--- a/scripts/create_report.py
+++ b/scripts/create_report.py
@@ -98,7 +98,7 @@ class extend_report():
         number_hosts = self.target_hosts
         if number_hosts % self.slice_max:
             number_of_slices = number_hosts // self.slice_max + 1
-            hosts_per_slice = number_hosts // number_of_slices
+            hosts_per_slice = number_hosts // number_of_slices + 1
         else:
             number_of_slices = number_hosts // self.slice_max
             hosts_per_slice = number_hosts // number_of_slices


### PR DESCRIPTION
Using:  `hosts=23923`
metadata without the `+1`
```
"report_slices": {
        "2b1d8d0a-87d2-4ca3-a27c-fa8a7bd11d97": {
            "number_hosts": 7973
        },
        "d065f8d6-3a18-42cf-863e-99494721986f": {
            "number_hosts": 7973
        },
        "b9d7a3cd-528d-436d-bf36-dc688b8d91c9": {
            "number_hosts": 7973
        },
        "5fa15a3e-b3cd-4d65-ade4-45d1d047048c": {
            "number_hosts": 2
        }
```
Metadata with the plus one
```
"report_slices": {
        "2022cbfd-9e58-4cd2-8888-7a4af87e19bd": {
            "number_hosts": 7974
        },
        "52f9720d-e2ea-4dc9-bf18-db574c7f56ee": {
            "number_hosts": 7974
        },
        "38b79695-31da-47b7-a9a8-4c55aa24bd65": {
            "number_hosts": 7973
        }
    }
```
