### PR TITLE
Pinned the insights pipeline library to v2 for smoke tests job

### DIFF
--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -2,7 +2,7 @@
 * Requires: https://github.com/RedHatInsights/insights-pipeline-lib
 */
 
-@Library("github.com/RedHatInsights/insights-pipeline-lib") _
+@Library("github.com/RedHatInsights/insights-pipeline-lib@v2") _
 
 
 // this 'if' statement makes sure this is a PR, so we don't run smoke tests again


### PR DESCRIPTION
There was an update to the insights pipeline library, so we have to pinned our test job to use `v2` until we convert it to use `v3`.