### PR TITLE
Smoke tests are failing possibly due to the need to split platform services

### DIFF
--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -14,7 +14,7 @@ if (env.CHANGE_ID) {
         // the service-set/component for this app in e2e-deploy "templates"
         ocDeployerComponentPath: "subscriptions",
         // the service sets to deploy into the test environment
-        ocDeployerServiceSets: "platform,platform-mq,subscriptions",
+        ocDeployerServiceSets: "ingress,inventory,platform-mq,subscriptions",
         // the iqe plugins to install for the test
         iqePlugins: ["iqe-yupana-plugin"],
         // the pytest marker to use when calling `iqe tests all`


### PR DESCRIPTION
Updating smoke deployment, basically the platform service set was getting too bulky and slowing down smoke deployments + using up quotas.