### PR TITLE
Enable batch logging for cloudwatch

### DIFF
--- a/yupana/config/settings/base.py
+++ b/yupana/config/settings/base.py
@@ -114,7 +114,7 @@ if CW_AWS_ACCESS_KEY_ID:
             'log_group': CW_LOG_GROUP,
             'stream_name': NAMESPACE,
             'formatter': LOGGING_FORMATTER,
-            'use_queues': False,
+            'use_queues': True,
             'create_log_group': False,
         }
     except ClientError as cerr:
@@ -127,7 +127,7 @@ if CW_AWS_ACCESS_KEY_ID:
                 'log_group': CW_LOG_GROUP,
                 'stream_name': NAMESPACE,
                 'formatter': LOGGING_FORMATTER,
-                'use_queues': False,
+                'use_queues': True,
                 'create_log_group': False,
             }
         else:


### PR DESCRIPTION
We are seeing cloudwatch rate limiting errors in the app:

```
An error occurred (ThrottlingException) when calling the PutLogEvents operation (reached max retries: 4): Rate exceeded
```

This PR enables batch logging. Explanation of 'use_queues' from https://watchtower.readthedocs.io/en/latest/_modules/watchtower.html

```
    :param use_queues:
        If **True**, logs will be queued on a per-stream basis and sent in batches. To manage the queues, a queue
        handler thread will be spawned.
```