### PR TITLE
Remove ip_addrs & mac_addrs fields if empty

### DIFF
--- a/yupana/processor/report_slice_processor.py
+++ b/yupana/processor/report_slice_processor.py
@@ -193,18 +193,15 @@ class ReportSliceProcessor(AbstractProcessor):  # pylint: disable=too-many-insta
         return candidates
 
     def _remove_ip_addresses(self, host: dict):
-        """Remove 'ip_addresses' field. """
+        """Remove 'ip_addresses' field."""
         if 'ip_addresses' in host:
             ip_addresses = host['ip_addresses']
-            """Remove empty strings from list, if any."""
-            while("" in ip_addresses):
-                ip_addresses.remove("")
             if not ip_addresses:
                 del host['ip_addresses']
                 LOG.info(
                     format_message(
                         self.prefix,
-                        "Removed empty ip_addresses fact.",
+                        'Removed empty ip_addresses fact.',
                         account_number=self.account_number,
                         report_platform_id=self.report_platform_id
                     )
@@ -212,18 +209,15 @@ class ReportSliceProcessor(AbstractProcessor):  # pylint: disable=too-many-insta
         return host
 
     def _remove_mac_addresses(self, host: dict):
-        """Remove 'mac_addresses' field. """
+        """Remove 'mac_addresses' field."""
         if 'mac_addresses' in host:
             mac_addresses = host['mac_addresses']
-            """Remove empty strings from list, if any."""
-            while("" in mac_addresses):
-                mac_addresses.remove("")
             if not mac_addresses:
                 del host['mac_addresses']
                 LOG.info(
                     format_message(
                         self.prefix,
-                        "Removed empty mac_addresses fact.",
+                        'Removed empty mac_addresses fact.',
                         account_number=self.account_number,
                         report_platform_id=self.report_platform_id
                     )

--- a/yupana/processor/report_slice_processor.py
+++ b/yupana/processor/report_slice_processor.py
@@ -192,36 +192,36 @@ class ReportSliceProcessor(AbstractProcessor):  # pylint: disable=too-many-insta
                       for key in host.keys() if key not in ['cause', 'status_code']}
         return candidates
 
-    def _remove_ip_addresses(self, host: dict):
+    def _remove_empty_ip_addresses(self, host: dict):
         """Remove 'ip_addresses' field."""
-        if 'ip_addresses' in host:
-            ip_addresses = host['ip_addresses']
-            if not ip_addresses:
-                del host['ip_addresses']
-                LOG.info(
-                    format_message(
-                        self.prefix,
-                        'Removed empty ip_addresses fact.',
-                        account_number=self.account_number,
-                        report_platform_id=self.report_platform_id
-                    )
-                )
+        ip_addresses = host.get('ip_addresses')
+        if ip_addresses is None or ip_addresses:
+            return host
+
+        del host['ip_addresses']
+        LOG.info(
+            format_message(
+                self.prefix,
+                'Removed empty ip_addresses fact.',
+                account_number=self.account_number,
+                report_platform_id=self.report_platform_id
+            ))
         return host
 
-    def _remove_mac_addresses(self, host: dict):
+    def _remove_empty_mac_addresses(self, host: dict):
         """Remove 'mac_addresses' field."""
-        if 'mac_addresses' in host:
-            mac_addresses = host['mac_addresses']
-            if not mac_addresses:
-                del host['mac_addresses']
-                LOG.info(
-                    format_message(
-                        self.prefix,
-                        'Removed empty mac_addresses fact.',
-                        account_number=self.account_number,
-                        report_platform_id=self.report_platform_id
-                    )
-                )
+        mac_addresses = host.get('mac_addresses')
+        if mac_addresses is None or mac_addresses:
+            return host
+
+        del host['mac_addresses']
+        LOG.info(
+            format_message(
+                self.prefix,
+                'Removed empty mac_addresses fact.',
+                account_number=self.account_number,
+                report_platform_id=self.report_platform_id
+            ))
         return host
 
     def _match_regex_and_find_version(self, os_release):
@@ -296,8 +296,9 @@ class ReportSliceProcessor(AbstractProcessor):  # pylint: disable=too-many-insta
         if 'system_profile' in host:
             host = self._transform_os_release(host)
             host = self._transform_os_kernel_version(host)
-            host = self._remove_ip_addresses(host)
-            host = self._remove_mac_addresses(host)
+
+        host = self._remove_empty_ip_addresses(host)
+        host = self._remove_empty_mac_addresses(host)
         return host
 
     # pylint:disable=too-many-locals

--- a/yupana/processor/report_slice_processor.py
+++ b/yupana/processor/report_slice_processor.py
@@ -192,6 +192,44 @@ class ReportSliceProcessor(AbstractProcessor):  # pylint: disable=too-many-insta
                       for key in host.keys() if key not in ['cause', 'status_code']}
         return candidates
 
+    def _remove_ip_addresses(self, host: dict):
+        """Remove 'ip_addresses' field. """
+        if 'ip_addresses' in host:
+            ip_addresses = host['ip_addresses']
+            """Remove empty strings from list, if any."""
+            while("" in ip_addresses):
+                ip_addresses.remove("")
+            if not ip_addresses:
+                del host['ip_addresses']
+                LOG.info(
+                    format_message(
+                        self.prefix,
+                        "Removed empty ip_addresses fact.",
+                        account_number=self.account_number,
+                        report_platform_id=self.report_platform_id
+                    )
+                )
+        return host
+
+    def _remove_mac_addresses(self, host: dict):
+        """Remove 'mac_addresses' field. """
+        if 'mac_addresses' in host:
+            mac_addresses = host['mac_addresses']
+            """Remove empty strings from list, if any."""
+            while("" in mac_addresses):
+                mac_addresses.remove("")
+            if not mac_addresses:
+                del host['mac_addresses']
+                LOG.info(
+                    format_message(
+                        self.prefix,
+                        "Removed empty mac_addresses fact.",
+                        account_number=self.account_number,
+                        report_platform_id=self.report_platform_id
+                    )
+                )
+        return host
+
     def _match_regex_and_find_version(self, os_release):
         """Match Regex with os_release and return os_version."""
         source_os_release = os_release.strip()
@@ -264,6 +302,8 @@ class ReportSliceProcessor(AbstractProcessor):  # pylint: disable=too-many-insta
         if 'system_profile' in host:
             host = self._transform_os_release(host)
             host = self._transform_os_kernel_version(host)
+            host = self._remove_ip_addresses(host)
+            host = self._remove_mac_addresses(host)
         return host
 
     # pylint:disable=too-many-locals

--- a/yupana/processor/report_slice_processor.py
+++ b/yupana/processor/report_slice_processor.py
@@ -202,7 +202,8 @@ class ReportSliceProcessor(AbstractProcessor):  # pylint: disable=too-many-insta
         LOG.info(
             format_message(
                 self.prefix,
-                'Removed empty ip_addresses fact.',
+                "Removed empty ip_addresses fact for host with FQDN '%s'"
+                % (host.get('fqdn', '')),
                 account_number=self.account_number,
                 report_platform_id=self.report_platform_id
             ))
@@ -218,7 +219,8 @@ class ReportSliceProcessor(AbstractProcessor):  # pylint: disable=too-many-insta
         LOG.info(
             format_message(
                 self.prefix,
-                'Removed empty mac_addresses fact.',
+                "Removed empty mac_addresses fact for host with FQDN '%s'"
+                % (host.get('fqdn', '')),
                 account_number=self.account_number,
                 report_platform_id=self.report_platform_id
             ))
@@ -253,7 +255,8 @@ class ReportSliceProcessor(AbstractProcessor):  # pylint: disable=too-many-insta
         if not os_version:
             del host['system_profile']['os_release']
             LOG.info(format_message(
-                self.prefix, 'Removed empty os_release fact',
+                self.prefix, "Removed empty os_release fact for host with FQDN '%s'"
+                % (host.get('fqdn', '')),
                 account_number=self.account_number,
                 report_platform_id=self.report_platform_id))
             return host
@@ -284,8 +287,8 @@ class ReportSliceProcessor(AbstractProcessor):  # pylint: disable=too-many-insta
         host['system_profile']['os_kernel_version'] = version_value
         LOG.info(
             format_message(
-                self.prefix, "os_kernel_version transformed '%s' -> '%s'"
-                % (os_kernel_version, version_value),
+                self.prefix, "os_kernel_version transformed '%s' -> '%s' for host with FQDN '%s'"
+                % (os_kernel_version, version_value, host.get('fqdn', '')),
                 account_number=self.account_number,
                 report_platform_id=self.report_platform_id))
 

--- a/yupana/processor/tests_report_slice_processor.py
+++ b/yupana/processor/tests_report_slice_processor.py
@@ -705,6 +705,13 @@ class ReportSliceProcessorTests(TestCase):
         host = self.processor._remove_empty_mac_addresses(host)
         self.assertEqual(host, {})
 
+    def test_remove_both_empty_ip_mac_addresses(self):
+        """Test remove both empty ip and mac addresses."""
+        host = {}
+        host = self.processor._remove_empty_ip_addresses(host)
+        host = self.processor._remove_empty_mac_addresses(host)
+        self.assertEqual(host, {})
+
     def test_do_not_remove_set_ip_addresses(self):
         """Test do not remove set host ip_addresses."""
         host = {

--- a/yupana/processor/tests_report_slice_processor.py
+++ b/yupana/processor/tests_report_slice_processor.py
@@ -690,3 +690,17 @@ class ReportSliceProcessorTests(TestCase):
         os_version = self.processor._match_regex_and_find_version(
             host['system_profile']['os_release'])
         self.assertEqual(host_os_version, os_version)
+
+    def test_remove_ip_addresses(self):
+        """Test remove host ip_addresses."""
+        host = {
+            'ip_addresses': []}
+        host = self.processor._remove_ip_addresses(host)
+        self.assertEqual(host, {})
+
+    def test_remove_mac_addresses(self):
+        """Test remove host mac_addresses."""
+        host = {
+            'mac_addresses': []}
+        host = self.processor._remove_mac_addresses(host)
+        self.assertEqual(host, {})

--- a/yupana/processor/tests_report_slice_processor.py
+++ b/yupana/processor/tests_report_slice_processor.py
@@ -691,30 +691,30 @@ class ReportSliceProcessorTests(TestCase):
             host['system_profile']['os_release'])
         self.assertEqual(host_os_version, os_version)
 
-    def test_remove_ip_addresses(self):
+    def test_remove_empty_ip_addresses(self):
         """Test remove host ip_addresses."""
         host = {
             'ip_addresses': []}
-        host = self.processor._remove_ip_addresses(host)
+        host = self.processor._remove_empty_ip_addresses(host)
         self.assertEqual(host, {})
 
-    def test_remove_mac_addresses(self):
+    def test_remove_empty_mac_addresses(self):
         """Test remove host mac_addresses."""
         host = {
             'mac_addresses': []}
-        host = self.processor._remove_mac_addresses(host)
+        host = self.processor._remove_empty_mac_addresses(host)
         self.assertEqual(host, {})
 
-    def test_do_not_remove_ip_addresses(self):
-        """Test do not remove host ip_addresses."""
+    def test_do_not_remove_set_ip_addresses(self):
+        """Test do not remove set host ip_addresses."""
         host = {
             'ip_addresses': ['192.168.10.10']}
-        host = self.processor._remove_ip_addresses(host)
+        host = self.processor._remove_empty_ip_addresses(host)
         self.assertEqual(host, {'ip_addresses': ['192.168.10.10']})
 
-    def test_do_not_remove_mac_addresses(self):
-        """Test do not remove host mac_addresses."""
+    def test_do_not_remove_set_mac_addresses(self):
+        """Test do not remove set host mac_addresses."""
         host = {
             'mac_addresses': ['aa:bb:00:11:22:33']}
-        host = self.processor._remove_mac_addresses(host)
+        host = self.processor._remove_empty_mac_addresses(host)
         self.assertEqual(host, {'mac_addresses': ['aa:bb:00:11:22:33']})

--- a/yupana/processor/tests_report_slice_processor.py
+++ b/yupana/processor/tests_report_slice_processor.py
@@ -704,3 +704,17 @@ class ReportSliceProcessorTests(TestCase):
             'mac_addresses': []}
         host = self.processor._remove_mac_addresses(host)
         self.assertEqual(host, {})
+
+    def test_do_not_remove_ip_addresses(self):
+        """Test do not remove host ip_addresses."""
+        host = {
+            'ip_addresses': ['192.168.10.10']}
+        host = self.processor._remove_ip_addresses(host)
+        self.assertEqual(host, {'ip_addresses': ['192.168.10.10']})
+
+    def test_do_not_remove_mac_addresses(self):
+        """Test do not remove host mac_addresses."""
+        host = {
+            'mac_addresses': ['aa:bb:00:11:22:33']}
+        host = self.processor._remove_mac_addresses(host)
+        self.assertEqual(host, {'mac_addresses': ['aa:bb:00:11:22:33']})


### PR DESCRIPTION
The hypervisor has empty arrays in `ip_addresses` and `mac_addresses` fields. This will fail validation on the inventory side and prevent the host record from appearing there. This has been handled already in the `foreman_rh_cloud` plugin under [foreman_rh_cloud/pull/249](https://github.com/theforeman/foreman_rh_cloud/pull/249). This PR removes both these fields when they have empty arrays as values.
The PR needs a rebase on top of [yupana/pull/323](https://github.com/quipucords/yupana/pull/323/files) once it's merged and I could then include these method calls in [_transform_single_host](https://github.com/quipucords/yupana/pull/323/files#diff-f049d03813e04872b2e244ca395a9aaaR269).