### PR TITLE
fixes #23 - Improve Liveness and Readiness checks

### DIFF
--- a/yupana/api/status/tests_view.py
+++ b/yupana/api/status/tests_view.py
@@ -34,8 +34,8 @@ class StatusViewTest(TestCase):
         self.assertEqual(json_result['api_version'], 1)
 
     @patch('api.status.view.list_name_of_processors')
-    def test_test_test(self, mock_active_processor):
-        """Test the status endpoint."""
+    def test_status_with_dead_thread(self, mock_active_processor):
+        """Test the status endpoint with some exited thread."""
         mock_active_processor.return_value = ['report_consumer', 'report_processor']
         url = reverse('server-status')
         res = self.client.get(url)

--- a/yupana/api/status/tests_view.py
+++ b/yupana/api/status/tests_view.py
@@ -17,6 +17,8 @@
 """Test the status API."""
 
 
+from unittest.mock import patch
+
 from django.test import TestCase
 from django.urls import reverse
 
@@ -30,3 +32,11 @@ class StatusViewTest(TestCase):
         response = self.client.get(url)
         json_result = response.json()
         self.assertEqual(json_result['api_version'], 1)
+
+    @patch('api.status.view.list_name_of_processors')
+    def test_test_test(self, mock_active_processor):
+        """Test the status endpoint."""
+        mock_active_processor.return_value = ['report_consumer', 'report_processor']
+        url = reverse('server-status')
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, 500)

--- a/yupana/api/status/view.py
+++ b/yupana/api/status/view.py
@@ -16,9 +16,7 @@
 #
 
 """View for server status."""
-import threading
-
-from processor.processor_utils import PROCESSOR_INSTANCES
+from processor.processor_utils import list_name_of_active_threads, list_name_of_processors
 from rest_framework import permissions, status as http_status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
@@ -80,9 +78,9 @@ def status(request):
     serializer = StatusSerializer(status_info)
     server_info = serializer.data
     server_info['server_address'] = request.META.get('HTTP_HOST', 'localhost')
-    processes = list(map(lambda i: i.processor_name, PROCESSOR_INSTANCES))
-    threads = list(map(lambda i: i.name, threading.enumerate()))
-    if not all(item in threads for item in processes):
+    processor = list_name_of_processors()
+    threads = list_name_of_active_threads()
+    if not all(item in threads for item in processor):
         return Response('Report processor thread exited',
                         status=http_status.HTTP_500_INTERNAL_SERVER_ERROR)
     return Response(server_info)

--- a/yupana/api/status/view.py
+++ b/yupana/api/status/view.py
@@ -16,8 +16,10 @@
 #
 
 """View for server status."""
+import threading
 
-from rest_framework import permissions
+from processor.processor_utils import PROCESSOR_INSTANCES
+from rest_framework import permissions, status as http_status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
 
@@ -78,4 +80,9 @@ def status(request):
     serializer = StatusSerializer(status_info)
     server_info = serializer.data
     server_info['server_address'] = request.META.get('HTTP_HOST', 'localhost')
+    processes = list(map(lambda i: i.processor_name, PROCESSOR_INSTANCES))
+    threads = list(map(lambda i: i.name, threading.enumerate()))
+    if not all(item in threads for item in processes):
+        return Response('Report processor thread exited',
+                        status=http_status.HTTP_500_INTERNAL_SERVER_ERROR)
     return Response(server_info)

--- a/yupana/api/status/view.py
+++ b/yupana/api/status/view.py
@@ -84,11 +84,11 @@ def status(request):
     serializer = StatusSerializer(status_info)
     server_info = serializer.data
     server_info['server_address'] = request.META.get('HTTP_HOST', 'localhost')
-    processors = list_name_of_processors()
-    threads = list_name_of_active_threads()
-    if not all(item in threads for item in processors):
-        dead_threads = set(processors).difference(threads)
-        LOG.error(format_message('SERVICE STATUS', 'Dead processors - %s' % dead_threads))
+    total_processors_names = list_name_of_processors()
+    active_threads_names = list_name_of_active_threads()
+    if not all(item in active_threads_names for item in total_processors_names):
+        dead_processors = set(total_processors_names).difference(active_threads_names)
+        LOG.error(format_message('SERVICE STATUS', 'Dead processors - %s' % dead_processors))
         return Response('ERROR: Processor thread exited',
                         status=http_status.HTTP_500_INTERNAL_SERVER_ERROR)
     return Response(server_info)

--- a/yupana/processor/processor_utils.py
+++ b/yupana/processor/processor_utils.py
@@ -17,6 +17,7 @@
 """Utilities for all of the processor classes."""
 import asyncio
 import logging
+import threading
 from time import sleep
 
 from config.settings.base import (SLEEP_PERIOD_WHEN_EVENT_LOOP_ERROR)
@@ -29,6 +30,16 @@ REPORT_PROCESSING_LOOP = asyncio.new_event_loop()
 SLICE_PROCESSING_LOOP = asyncio.new_event_loop()
 GARBAGE_COLLECTION_LOOP = asyncio.new_event_loop()
 PROCESSOR_INSTANCES = []  # this list holds processor instances that have kafka components
+
+
+def list_name_of_active_threads():
+    """List of names of active thread."""
+    return list(map(lambda i: i.name, threading.enumerate()))
+
+
+def list_name_of_processors():
+    """List of processor."""
+    return list(map(lambda i: i.processor_name, PROCESSOR_INSTANCES))
 
 
 def format_message(prefix, message, account_number=None,

--- a/yupana/processor/report_consumer.py
+++ b/yupana/processor/report_consumer.py
@@ -48,6 +48,7 @@ MSG_UPLOADS = Counter('yupana_message_uploads',
 
 KAFKA_ERRORS = Counter('yupana_kafka_errors', 'Number of Kafka errors')
 DB_ERRORS = Counter('yupana_db_errors', 'Number of db errors')
+PROCESSOR_NAME = 'report_consumer'
 
 
 class QPCReportException(Exception):
@@ -78,6 +79,7 @@ class ReportConsumer():
 
     def __init__(self):
         """Create a report consumer."""
+        self.processor_name = PROCESSOR_NAME
         self.should_run = True
         self.prefix = 'REPORT CONSUMER'
         self.account_number = None
@@ -258,6 +260,7 @@ def initialize_upload_report_consumer():  # pragma: no cover
     :returns None
     """
     event_loop_thread = threading.Thread(
-        target=create_upload_report_consumer_loop, args=(UPLOAD_REPORT_CONSUMER_LOOP,))
+        target=create_upload_report_consumer_loop, name=PROCESSOR_NAME,
+        args=(UPLOAD_REPORT_CONSUMER_LOOP,))
     event_loop_thread.daemon = True
     event_loop_thread.start()

--- a/yupana/processor/report_processor.py
+++ b/yupana/processor/report_processor.py
@@ -65,6 +65,7 @@ HOSTS_PER_REPORT_QPC = Gauge('hosts_per_qpc_rep',
 HOSTS_COUNTER = Counter('yupana_hosts_count',
                         'Total number of hosts uploaded',
                         ['account_number', 'source'])
+PROCESSOR_NAME = 'report_processor'
 
 
 class FailDownloadException(Exception):
@@ -96,6 +97,7 @@ class ReportProcessor(AbstractProcessor):  # pylint: disable=too-many-instance-a
 
     def __init__(self):
         """Create a report processor."""
+        self.processor_name = PROCESSOR_NAME
         state_functions = {
             Report.NEW: self.transition_to_started,
             Report.STARTED: self.transition_to_downloaded,
@@ -770,6 +772,7 @@ def initialize_report_processor():  # pragma: no cover
     :returns None
     """
     event_loop_thread = threading.Thread(target=asyncio_report_processor_thread,
+                                         name=PROCESSOR_NAME,
                                          args=(REPORT_PROCESSING_LOOP,))
     event_loop_thread.daemon = True
     event_loop_thread.start()

--- a/yupana/processor/report_slice_processor.py
+++ b/yupana/processor/report_slice_processor.py
@@ -53,6 +53,7 @@ UPLOAD_TOPIC = 'platform.inventory.host-ingress'  # placeholder topic
 OS_RELEASE_PATTERN = re.compile(
     r'(?P<name>[a-zA-Z\s]*)?\s*(?P<version>[\d\.]*)\s*(\((?P<code>\S*)\))?'
 )
+PROCESSOR_NAME = 'report_slice_processor'
 
 
 class RetryUploadTimeException(Exception):
@@ -72,6 +73,7 @@ class ReportSliceProcessor(AbstractProcessor):  # pylint: disable=too-many-insta
 
     def __init__(self):
         """Create a report slice state machine."""
+        self.processor_name = PROCESSOR_NAME
         state_functions = {
             ReportSlice.RETRY_VALIDATION: self.transition_to_validated,
             ReportSlice.NEW: self.transition_to_started,
@@ -447,6 +449,7 @@ def initialize_report_slice_processor():  # pragma: no cover
     :returns None
     """
     event_loop_thread = threading.Thread(target=asyncio_report_processor_thread,
+                                         name=PROCESSOR_NAME,
                                          args=(SLICE_PROCESSING_LOOP,))
     event_loop_thread.daemon = True
     event_loop_thread.start()


### PR DESCRIPTION
With this PR in status API `/api/subscriptions/v1/status/` we will be checking if all the report processors/Threads are alive. 
If any of the report processor thread is exited then API will return 500 status code and liveness probe will get triggered. 