### PR TITLE
Both `account_number` and `org_id` needs to be strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ custom-data:
 	rm -rf old_reports_temp
 
 upload-data:
-	curl -vvvv -H "x-rh-identity: $(shell echo '{"identity": {"account_number": $(RH_ACCOUNT_NUMBER), "internal": {"org_id": $(RH_ORG_ID)}}}' | base64)" \
+	curl -vvvv -H "x-rh-identity: $(shell echo '{"identity": {"account_number": "$(RH_ACCOUNT_NUMBER)", "internal": {"org_id": "$(RH_ORG_ID)"}}}' | base64)" \
 		-F "file=@$(file);type=application/vnd.redhat.qpc.tar+tgz" \
 		-H "x-rh-insights-request-id: 52df9f748eabcfea" \
 		$(INGRESS_URL) \


### PR DESCRIPTION
Otherwise Ingress fails with `Bad Request: missing x-rh-identity header`