### PR TITLE
transform ipv6, name fields of network-interfaces

### DIFF
--- a/yupana/processor/report_slice_processor.py
+++ b/yupana/processor/report_slice_processor.py
@@ -338,7 +338,7 @@ class ReportSliceProcessor(AbstractProcessor):  # pylint: disable=too-many-insta
                 format_message(
                     self.prefix,
                     "Transformed %s for host with FQDN '%s'"
-                    % (",".join(modified_fields), host.get('fqdn', '')),
+                    % (','.join(modified_fields), host.get('fqdn', '')),
                     account_number=self.account_number,
                     report_platform_id=self.report_platform_id))
 
@@ -347,7 +347,7 @@ class ReportSliceProcessor(AbstractProcessor):  # pylint: disable=too-many-insta
 
     @staticmethod
     def _transform_ipv6(nic: dict, increment_counts: dict):
-        """ Remove empty 'network_interfaces[]['ipv6_addresses']."""
+        """Remove empty 'network_interfaces[]['ipv6_addresses']."""
         old_len = len(nic['ipv6_addresses'])
         nic['ipv6_addresses'] = list(
             filter(lambda ipv6: ipv6, nic['ipv6_addresses'])

--- a/yupana/processor/tests_report_slice_processor.py
+++ b/yupana/processor/tests_report_slice_processor.py
@@ -794,3 +794,58 @@ class ReportSliceProcessorTests(TestCase):
                          'name':'eth0'}]
                 }
             })
+
+    def test_remove_nic_when_empty_string_in_name(self):
+        """Test to remove network_interface when name is empty."""
+        host = {
+            'system_profile': {
+                'network_interfaces': [
+                    {'ipv4_addresses': [], 'ipv6_addresses': [], 'name': ''},
+                    {'ipv4_addresses': [], 'ipv6_addresses': []},
+                    {'ipv4_addresses': [],
+                     'ipv6_addresses': [], 'name': 'eth0'}
+                ]
+            }}
+
+        host = self.processor._transform_single_host(host)
+        self.assertEqual(
+            host,
+            {
+                'system_profile': {
+                    'network_interfaces': [
+                        {'ipv4_addresses': [], 'ipv6_addresses': [],
+                         'name':'eth0'}]
+                }
+            })
+
+    def test_remove_empty_strings_in_ipv6_addresses(self):
+        """Test to verify transformation for 'ipv6 addresses' in host."""
+        ipv6_address = '2021:0db8:85a3:0000:0000:8a2e:0370:7335'
+        host = {
+            'system_profile': {
+                'network_interfaces': [
+                    {'ipv4_addresses': [],
+                     'ipv6_addresses': ['', ipv6_address, ''],
+                     'name':'eth0'},
+                    {'ipv4_addresses': [],
+                     'ipv6_addresses': [''], 'name':'eth1'}]
+            }}
+
+        host = self.processor._transform_single_host(host)
+        self.assertEqual(
+            host,
+            {
+                'system_profile': {
+                    'network_interfaces': [
+                        {'ipv4_addresses': [],
+                         'ipv6_addresses': [ipv6_address],
+                         'name':'eth0'},
+                        {'ipv4_addresses': [],
+                         'ipv6_addresses': [], 'name':'eth1'}]
+                }
+            })
+        nics = host['system_profile']['network_interfaces']
+        self.assertEqual(len(nics), 2)
+        filtered_nics = [nic for nic in nics if nic.get('name') == 'eth0']
+        self.assertTrue(len(filtered_nics))
+        self.assertEqual(len(filtered_nics[0]['ipv6_addresses']), 1)


### PR DESCRIPTION
With this commit, yupana filters out nics with empty name &
also removes empty strings from ipv6 field.

Fixes issues - [Yupana-36](https://projects.engineering.redhat.com/browse/YUPANA-36), [Yupana-29](https://projects.engineering.redhat.com/browse/YUPANA-29)