### PR TITLE
Update smoke job to use the foreman IQE plugin 

### DIFF
--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -16,7 +16,7 @@ if (env.CHANGE_ID) {
         // the service sets to deploy into the test environment
         ocDeployerServiceSets: "ingress,inventory,platform-mq,subscriptions",
         // the iqe plugins to install for the test
-        iqePlugins: ["iqe-yupana-plugin"],
+        iqePlugins: ["iqe-foreman-rh-cloud-plugin"],
         // the pytest marker to use when calling `iqe tests all`
         pytestMarker: "yupana_smoke",
         // optional id for an IQE configuration file stored as a secret in Jenkins

--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -18,7 +18,7 @@ if (env.CHANGE_ID) {
         // the iqe plugins to install for the test
         iqePlugins: ["iqe-foreman-rh-cloud-plugin"],
         // the pytest marker to use when calling `iqe tests all`
-        pytestMarker: "yupana_smoke",
+        pytestMarker: "core",
         // optional id for an IQE configuration file stored as a secret in Jenkins
         //configFileCredentialsId: "myId",
     )


### PR DESCRIPTION
These tests would be now run as a smoke pipeline tests. 

```
<Package tests>
  <Module test_satellite_hosts.py>
    <Function test_satellite_report_upload[NON_VIRTWHO]>
    <Function test_satellite_report_upload[VIRTWHO]>
  <Module test_yupana_archive_operation.py>
    <Function test_yupana_report_upload>

```
These tests can be found in IQE on gitlab under iqe-foreman-rh-cloud-plugin 
