### PR TITLE
YUPANA #54 - Update stale_timestamp to same as insights-client

### DIFF
--- a/yupana/config/settings/base.py
+++ b/yupana/config/settings/base.py
@@ -346,6 +346,6 @@ KAFKA_PRODUCER_OVERRIDE_MAX_REQUEST_SIZE = os.getenv(
 )
 
 # Culling variables to compute the stale date
-# the time to live in number of days (the time from insertion into HBI until the stale date)
-DISCOVERY_HOST_TTL = os.getenv('DISCOVERY_HOST_TTL', '30')
-SATELLITE_HOST_TTL = os.getenv('SATELLITE_HOST_TTL', '30')
+# the time to live in number of hours (the time from insertion into HBI until the stale date)
+DISCOVERY_HOST_TTL = os.getenv('DISCOVERY_HOST_TTL', '29')
+SATELLITE_HOST_TTL = os.getenv('SATELLITE_HOST_TTL', '29')

--- a/yupana/processor/abstract_processor.py
+++ b/yupana/processor/abstract_processor.py
@@ -749,7 +749,7 @@ class AbstractProcessor(ABC):  # pylint: disable=too-many-instance-attributes
                                          'report_slice_id': str(report_slice_id),
                                          'account': self.account_number,
                                          'source': self.report_or_slice.source}})
-            host['stale_timestamp'] = self.get_stale_date()
+            host['stale_timestamp'] = self.get_stale_time()
             host['reporter'] = 'yupana'
             host['facts'] = host_facts
             found_facts = False
@@ -777,11 +777,11 @@ class AbstractProcessor(ABC):  # pylint: disable=too-many-instance-attributes
 
         return candidate_hosts, hosts_without_facts
 
-    def get_stale_date(self):
+    def get_stale_time(self):
         """Compute the stale date based on the host source."""
         ttl = int(DISCOVERY_HOST_TTL)
         if self.report_or_slice.source == 'satellite':
             ttl = int(SATELLITE_HOST_TTL)
         current_time = datetime.utcnow()
-        stale_time = current_time + timedelta(days=ttl)
+        stale_time = current_time + timedelta(hours=ttl)
         return stale_time.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'

--- a/yupana/processor/tests_report_slice_processor.py
+++ b/yupana/processor/tests_report_slice_processor.py
@@ -592,14 +592,14 @@ class ReportSliceProcessorTests(TestCase):
         self.check_variables_are_reset()
 
     def test_get_stale_time(self):
-        """Test the get stale date method."""
+        """Test the get stale time method."""
         self.processor.report_or_slice = self.report_record
         self.processor.report_or_slice.source = 'satellite'
         self.processor.report_or_slice.save()
         current_time = datetime.utcnow()
-        stale_time = current_time + timedelta(days=int(SATELLITE_HOST_TTL))
+        stale_time = current_time + timedelta(hours=int(SATELLITE_HOST_TTL))
         expected = stale_time.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
-        actual = self.processor.get_stale_date()
+        actual = self.processor.get_stale_time()
         # the format looks like this: 2019-11-14T19:58:13.037Z
         # by cutting off the last 13 i am comparing 2019-11-14T
         # which is the year/month/day


### PR DESCRIPTION
Reference to puptoo setting: https://github.com/RedHatInsights/insights-puptoo/blob/527ec75405a82d5c7c397af4bafbb832dcd9c528/src/puptoo/app.py#L42