### PR TITLE
Refs #YUPANA-120 - Create ssl_context if no cacert specified

### DIFF
--- a/yupana/config/settings/base.py
+++ b/yupana/config/settings/base.py
@@ -63,6 +63,9 @@ def kafka_ssl_config():
             ssl_config['ssl_context'] = create_ssl_context(
                 cafile=KAFKA_BROKER.cacert
             )
+        else:
+            ssl_config['ssl_context'] = create_ssl_context()
+
         if KAFKA_BROKER.sasl and KAFKA_BROKER.sasl.username:
             ssl_config.update({
                 "security_protocol": KAFKA_BROKER.sasl.securityProtocol,


### PR DESCRIPTION
Fixes the below error observed in stage cluster. 
```
File "/opt/app-root/lib/python3.6/site-packages/aiokafka/client.py", line 106, in __init__
"`ssl_context` is mandatory if security_protocol=='SSL'")
ValueError: `ssl_context` is mandatory if security_protocol=='SSL'
```